### PR TITLE
chore: add action to build container

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,0 +1,60 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+    - name: Build and push Docker image (Multi-platform)
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}-cpu
+        labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Build and push Docker image (CUDA)
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile.cuda
+        platforms: linux/amd64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}-cuda
+        labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install PyTorch with CUDA support
+RUN pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r package/requirements.txt
+
+# Install the local package
+RUN pip install -e package
+
+# Make port 8888 available to the world outside this container
+EXPOSE 8888
+
+# Create a non-root user and switch to it
+RUN useradd -m jupyter
+USER jupyter
+
+# Run Jupyter when the container launches
+CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root"]

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,0 +1,35 @@
+# Use NVIDIA CUDA base image
+FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Install Python and system dependencies
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    git \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install PyTorch with CUDA support
+RUN pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Install any needed packages specified in requirements.txt
+RUN pip3 install --no-cache-dir -r package/requirements.txt
+
+# Install the local package
+RUN pip3 install -e package
+
+# Make port 8888 available to the world outside this container
+EXPOSE 8888
+
+# Create a non-root user and switch to it
+RUN useradd -m jupyter
+USER jupyter
+
+# Run Jupyter when the container launches
+CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root"]


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a GitHub Actions workflow to automate the building and pushing of Docker images, supporting both multi-platform and CUDA-specific builds.

CI:
- Add a GitHub Actions workflow to build and push Docker images to the GitHub Container Registry on pushes to the main branch and manual dispatch.

<!-- Generated by sourcery-ai[bot]: end summary -->