### PR TITLE
Revert "chore(deps): bump opentelemetry-exporter-otlp-proto-grpc from 1.25.0 to 1.28.2 in /package"

### DIFF
--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -971,7 +971,7 @@ opentelemetry-exporter-otlp-proto-common==1.25.0
     # via
     #   matextract (setup.py)
     #   opentelemetry-exporter-otlp-proto-grpc
-opentelemetry-exporter-otlp-proto-grpc==1.28.2
+opentelemetry-exporter-otlp-proto-grpc==1.25.0
     # via
     #   matextract (setup.py)
     #   chromadb


### PR DESCRIPTION
Reverts lamalab-org/matextract-book#167

## Summary by Sourcery

Chores:
- Revert the dependency version of opentelemetry-exporter-otlp-proto-grpc from 1.28.2 back to 1.25.0 in the package requirements.