### PR TITLE
docs: add note about how to match

### DIFF
--- a/content/evaluations/evaluations.ipynb
+++ b/content/evaluations/evaluations.ipynb
@@ -333,6 +333,17 @@
     "In the following, we will do this based on the `inputs` section of the data. As a first approximation, we will say that a ground truth \"matches\" an extraction result if it is the most similar from all extraction results. To solve this for all the elements of the extraction, we use the `deepdiff` library to measure how similar two dictionaries are, and then use the [Kuhn-Munkres algorithm](https://en.wikipedia.org/wiki/Hungarian_algorithm) to find the optimal assignments between ground truth and extraction.\n",
     "\n",
     "Note that in practice it is often better to not perform the matching on the entire extracted output but only on what one can define as an \"identifier\" of an entry. \n",
+    "\n",
+    "`````{admonition} On what to match\n",
+    ":class: note\n",
+    "\n",
+    "The choice of what fields of the schema the matching is performed on is crucial.\n",
+    "If one imagines extracting reactions with associated yields one could imagine matching reactions based on the reaction yield.\n",
+    "\n",
+    "This, however, is not the ideal way to match reactions as the interpretation of the results is counterintuitive: Chemists would intuitively match extracted results and ground truth based on the reaction SMILES (and conditions) and then compare the yields. If now the matching is performed on the yield, the evaluation would be counterintuitive to a chemist. For example, and incorrectly extracted  yield might lead to counterintuitive matches and thus a bad evaluation.\n",
+    "```\n",
+    "\n",
+    "\n",
     "For materials, this can be properties that might be a canonicalized representation of the material. For reactions, this might be the canonicalized reaction SMILES with condition information."
    ]
   },


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add a note explaining the importance of choosing appropriate fields for matching in evaluations, using the example of matching reactions based on reaction SMILES rather than yields.